### PR TITLE
Fixes in order to make TangoD2 work on FreeBSD. Both x32 and x64

### DIFF
--- a/build/command.make
+++ b/build/command.make
@@ -23,7 +23,7 @@ else
         OS              = "Solaris"
         message         = @(echo \033[31m $1 \033[0;0m1)
         Filter          = tango/sys/win32/%.d tango/sys/linux/%.d tango/sys/darwin/%.d tango/sys/freebsd/%.d
-    else ifeq ($(shell uname),Freebsd)
+    else ifeq ($(shell uname),FreeBSD)
         STATIC_LIB_EXT  = .a
         SHARED_LIB_EXT = .so
         OS              = "FreeBSD"
@@ -54,7 +54,7 @@ else ifeq ($(OS),"Linux")
     MKDIR = mkdir -p
     MV    = mv
     LN    = ln -s
-else ifeq ($(OS),"Freebsd")
+else ifeq ($(OS),"FreeBSD")
     RM    = rm -f
     RMDIR = rm -rf
     MKDIR = mkdir -p

--- a/tango/io/selector/PollSelector.d
+++ b/tango/io/selector/PollSelector.d
@@ -265,7 +265,9 @@ version (Posix)
          */
         override public int select(TimeSpan timeout)
         {
-            int to = (timeout != TimeSpan.max ? cast(int) timeout.millis : -1);
+            // int to = (timeout != TimeSpan.max ? cast(int) timeout.millis : -1); 
+            // FIXME: not sure how to fix it
+            int to = timeout.millis;
 
             debug (selector)
                 Stdout.formatln("--- PollSelector.select({0} ms): waiting on {1} handles",

--- a/tango/math/IEEE.d
+++ b/tango/math/IEEE.d
@@ -675,7 +675,7 @@ real ldexp(real n, int exp) /* intrinsic */
             fild exp;
             fld n;
             fscale;
-            fstp ST(1), ST(0);
+            fstp ST(1);//, ST(0);
         }
     }
     else
@@ -789,7 +789,7 @@ real logb(real x)
         asm {
             fld x;
             fxtract;
-            fstp ST(0), ST; // drop significand
+            fstp ST(0);//, ST; // drop significand
         }
     } else {
         return tango.stdc.math.logbl(x);
@@ -827,7 +827,7 @@ real scalbn(real x, int n)
             fild n;
             fld x;
             fscale;
-            fstp ST(1), ST;
+            fstp ST(1);//, ST;
         }
     } else {
         // NOTE: Not implemented in DMD

--- a/tango/math/Math.d
+++ b/tango/math/Math.d
@@ -1181,14 +1181,14 @@ L_largepositive:
         // Set scratchreal = real.max. 
         // squaring it will create infinity, and set overflow flag.
         mov word  ptr [ESP+8+8], 0x7FFE;
-        fstp ST(0), ST;
+        fstp ST(0);//, ST;
         fld real ptr [ESP+8];  // load scratchreal
         fmul ST(0), ST;        // square it, to create havoc!
 L_was_nan:
         add ESP,12+8;
         ret PARAMSIZE;
 L_largenegative:        
-        fstp ST(0), ST;
+        fstp ST(0);//, ST;
         fld1;
         fchs; // return -1. Underflow flag is not set.
         add ESP,12+8;
@@ -1267,7 +1267,7 @@ L_subnormal:
         fld1;
         fscale;
         fstp real ptr [ESP+8]; // scratchreal = 2^scratchint
-        fstp ST(0),ST;         // drop scratchint        
+        fstp ST(0);//,ST;         // drop scratchint        
         jmp L_normal;
         
 L_extreme: // Extreme exponent. X is very large positive, very
@@ -1286,7 +1286,7 @@ L_overflow:
         // squaring it will create infinity, and set overflow flag.
         mov word  ptr [ESP+8+8], 0x7FFE;
 L_waslargenegative:        
-        fstp ST(0), ST;
+        fstp ST(0);//, ST;
         fld real ptr [ESP+8];  // load scratchreal
         fmul ST(0), ST;        // square it, to create havoc!
 L_was_nan:

--- a/tango/stdc/posix/stdlib.d
+++ b/tango/stdc/posix/stdlib.d
@@ -325,7 +325,7 @@ else version( FreeBSD )
             p1 = &buf[$-1]; 
             while (fi != 0) { 
                 fj = modf(fi/10, &fi); 
-                *--p1 = cast(int)((fj+.03)*10) + '0'; 
+                *--p1 = cast(char)((cast(char) (fj+.03)*10) + '0');
                 r2++; 
             } 
             while (p1 < &buf[$-1]) 
@@ -347,7 +347,7 @@ else version( FreeBSD )
         while (p<=p1 && p<&buf[$-1]) { 
             arg *= 10; 
             arg = modf(arg, &fj); 
-            *p++ = cast(int)fj + '0'; 
+            *p++ = cast(char) (cast(char)(fj) + '0');
         } 
         if (p1 >= &buf[$-1]) { 
             buf[$-2] = '\0'; 

--- a/tango/stdc/posix/sys/select.d
+++ b/tango/stdc/posix/sys/select.d
@@ -156,7 +156,7 @@ else version( darwin )
 
     extern (D) int  FD_ISSET( int fd, fd_set* fdset )
     {
-        return fdset.fds_bits[__FDELT( fd )] & __FDMASK( fd );
+        return cast(int) (fdset.fds_bits[__FDELT( fd )] & __FDMASK( fd ));
     }
 
     extern (D) void FD_SET( int fd, fd_set* fdset )
@@ -180,7 +180,7 @@ else version( FreeBSD )
 
         extern (D) int __FDELT( int d )
         {
-            return d / _NFDBITS;
+            return cast(int) (d / _NFDBITS);
         }
 
         extern (D) __fd_mask __FDMASK( int d )

--- a/tango/util/compress/Zip.d
+++ b/tango/util/compress/Zip.d
@@ -39,7 +39,6 @@ import tango.time.Time : Time, TimeSpan;
 import tango.time.WallClock : WallClock;
 import tango.time.chrono.Gregorian : Gregorian;
 
-import Path = tango.io.Path;
 import Integer = tango.text.convert.Integer;
 
 debug(Zip) import tango.io.Stdout : Stderr;
@@ -2246,8 +2245,8 @@ void dosToTime(ushort dostime, ushort dosdate, out Time time)
 void timeToDos(Time time, out ushort dostime, out ushort dosdate)
 {
     // Treat Time.min specially
-    if( time == Time.min )
-        time = WallClock.now;
+    // if( time == Time.min ) FIXME: Again, this Time.opEquals error.
+        // time = WallClock.now; FIXME: ^
 
     // *muttering happily*
     auto date = Gregorian.generic.toDate(time);


### PR DESCRIPTION
SiegeLord please look into 
tango/io/selector/PollSelector.d 
tango/util/compress/Zip.d

There are sections marked with FIXME. They are temporarly workarounds because I don't know how to mess with all those Time packages. Probably you would be better person to fix that. Neither way, those hacks were required in order to build TangoD2 on FreeBSD. Otherwise I had errors like "TimeSpam isn't lvalue".
Probably TimeSpan.opEquals arguments set should be changed (remove ref from arguments).

Evrerything was compiled with DMD 2.059 (git-head).

In overall, Tango D2 works very nice on FreeBSD, both x32 (had to hack tango.math.\* a bit to catch up) and x64. Very well done! :)
