### PR TITLE
Add support for dub

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "tango-d2",
+    "name": "tango",
     "description": "A large general-purpose library. A port of the D1 Tango library.",
     "homepage": "https://github.com/SiegeLord/Tango-D2/",
     "license": "BSD",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "Tango-D2",
+    "description": "A large general-purpose library. A port of the D1 Tango library.",
+    "homepage": "https://github.com/SiegeLord/Tango-D2/",
+    "license": "BSD",
+    "authors": [
+        "SiegeLord",
+        "Origin Tango authors"
+    ],
+
+    "targetName": "Tango",
+    "targetPath": "lib",
+}
+

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
 
     "sourcePaths": ["tango/core", "tango/io", "tango/math", "tango/net", 
                     "tango/stdc", "tango/text", "tango/time", "tango/util"],
-    "sourcePaths-Windows": ["tango/sys/win32"],
+    "sourcePaths-windows": ["tango/sys/win32"],
     "sourcePaths-linux": ["tango/sys/linux"],
-    "sourcePaths-FreeBSD": ["tango/sys/freebsd"],
-    "sourcePaths-Solaris": ["tango/sys/solaris"],
-    "sourcePaths-OSX": ["tango/sys/darwin"],
+    "sourcePaths-freebsd": ["tango/sys/freebsd"],
+    "sourcePaths-solaris": ["tango/sys/solaris"],
+    "sourcePaths-osx": ["tango/sys/darwin"],
 
-    "excludedSourceFiles-Windows": ["tango/stdc/posix/*"],
+    "excludedSourceFiles-windows": ["tango/stdc/posix/*"],
 
     "importPaths": [""],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,13 @@
     "sourcePaths-Solaris": ["tango/sys/solaris"],
     "sourcePaths-OSX": ["tango/sys/darwin"],
 
+    "configurations": [
+	{
+	    "name": "shared",
+	    "targetType": "dynamicLibrary"
+	}
+    ],
+
     "targetName": "tango",
     "targetPath": ".",
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "Tango-D2",
+    "name": "tango-d2",
     "description": "A large general-purpose library. A port of the D1 Tango library.",
     "homepage": "https://github.com/SiegeLord/Tango-D2/",
     "license": "BSD",
@@ -8,7 +8,14 @@
         "Origin Tango authors"
     ],
 
+    "sourcePaths": ["tango/core", "tango/io", "tango/math", "tango/net", 
+		    "tango/stdc", "tango/text", "tango/time", "tango/util"],
+    "sourcePaths-Windows": ["tango/sys/win32"],
+    "sourcePaths-linux": ["tango/sys/linux"],
+    "sourcePaths-FreeBSD": ["tango/sys/freebsd"],
+    "sourcePaths-Solaris": ["tango/sys/solaris"],
+    "sourcePaths-OSX": ["tango/sys/darwin"],
+
     "targetName": "Tango",
     "targetPath": "lib",
 }
-

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "sourcePaths-Solaris": ["tango/sys/solaris"],
     "sourcePaths-OSX": ["tango/sys/darwin"],
 
-    "targetName": "Tango",
-    "targetPath": "lib",
+    "targetName": "tango",
+    "targetPath": ".",
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
 
     "excludedSourceFiles-windows": ["tango/stdc/posix/*"],
 
+    "versions-osx" : ["osx", "darwin"],
+    "versions-freebsd" : ["freebsd"],
+
     "importPaths": [""],
 
     "configurations": [
@@ -35,5 +38,5 @@
     ],
 
     "targetName": "tango",
-    "targetPath": ".",
+    "targetPath": "."
 }

--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
     "name": "tango",
     "description": "A large general-purpose library. A port of the D1 Tango library.",
     "homepage": "https://github.com/SiegeLord/Tango-D2/",
-    "license": "BSD",
+    "license": "BSD 3-clause",
     "authors": [
         "SiegeLord",
-        "Origin Tango authors"
+	"Kris Bell",
+	"Sean Kelly",
+	"Lars Ivar Igesund",
+        "other original Tango authors"
     ],
 
     "sourcePaths": ["tango/core", "tango/io", "tango/math", "tango/net", 
@@ -16,7 +19,15 @@
     "sourcePaths-Solaris": ["tango/sys/solaris"],
     "sourcePaths-OSX": ["tango/sys/darwin"],
 
+    "excludedSourceFiles-Windows": ["tango/stdc/posix/*"],
+
+    "importPaths": [""],
+
     "configurations": [
+	{
+            "name": "static",
+            "targetType": "staticLibrary"
+        },
         {
             "name": "shared",
             "targetType": "dynamicLibrary"

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
     "license": "BSD 3-clause",
     "authors": [
         "SiegeLord",
-	"Kris Bell",
-	"Sean Kelly",
-	"Lars Ivar Igesund",
+        "Kris Bell",
+        "Sean Kelly",
+        "Lars Ivar Igesund",
         "other original Tango authors"
     ],
 
     "sourcePaths": ["tango/core", "tango/io", "tango/math", "tango/net", 
-		    "tango/stdc", "tango/text", "tango/time", "tango/util"],
+                    "tango/stdc", "tango/text", "tango/time", "tango/util"],
     "sourcePaths-Windows": ["tango/sys/win32"],
     "sourcePaths-linux": ["tango/sys/linux"],
     "sourcePaths-FreeBSD": ["tango/sys/freebsd"],
@@ -24,7 +24,7 @@
     "importPaths": [""],
 
     "configurations": [
-	{
+        {
             "name": "static",
             "targetType": "staticLibrary"
         },

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "sourcePaths-OSX": ["tango/sys/darwin"],
 
     "configurations": [
-	{
-	    "name": "shared",
-	    "targetType": "dynamicLibrary"
-	}
+        {
+            "name": "shared",
+            "targetType": "dynamicLibrary"
+        }
     ],
 
     "targetName": "tango",


### PR DESCRIPTION
http://code.dlang.org is becoming the de facto standard as a D package repository, along with it's associated build tool `dub`. Adding this package.json file and then publishing to the code.dlang repo\* will allow people to express tango as a dependency for their project and have `dub` deal with downloading from this github repo and building.

There's a lot of quality code in tango, it seems sensible that it should be available through `dub`.

*I will do this if/when this pull is merged.
