### PR TITLE
Add missing common tango/sys files for Dub.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,17 @@
         "other original Tango authors"
     ],
 
-    "sourcePaths": ["tango/core", "tango/io", "tango/math", "tango/net",
-                    "tango/stdc", "tango/text", "tango/time", "tango/util"],
+    "sourcePaths": [
+        "tango/core", "tango/io", "tango/math", "tango/net", "tango/stdc",
+        "tango/sys/consts", "tango/text", "tango/time", "tango/util"
+    ],
+
+    "sourceFiles": [
+        "tango/sys/Common.d", "tango/sys/Environment.d",
+        "tango/sys/HomeFolder.d", "tango/sys/Pipe.d",
+        "tango/sys/Process.d", "tango/sys/SharedLib.d"
+    ],
+
     "sourcePaths-windows": ["tango/sys/win32"],
     "sourcePaths-linux": ["tango/sys/linux"],
     "sourcePaths-freebsd": ["tango/sys/freebsd"],
@@ -25,13 +34,7 @@
     "versions-osx" : ["osx", "darwin"],
     "versions-freebsd" : ["freebsd"],
 
-    "importPaths": ["tango/core", "tango/io", "tango/math", "tango/net",
-                    "tango/stdc", "tango/text", "tango/time", "tango/util"],
-    "importPaths-windows": ["tango/sys/win32"],
-    "importPaths-linux": ["tango/sys/linux"],
-    "importPaths-freebsd": ["tango/sys/freebsd"],
-    "importPaths-solaris": ["tango/sys/solaris"],
-    "importPaths-osx": ["tango/sys/darwin"],
+    "importPaths": ["."],
 
     "configurations": [
         {


### PR DESCRIPTION
This will also correctly set the import paths to always require the use of fully qualified module names. This is the behavior that was used for D1.

Previously, multiple import paths was set, example "tango/core". This allows to import tango/core/Array.d with just "import Array" instead of the fully qualified module name "import tango.core.Array".
