### PR TITLE
Add silenceWarnings to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
         }
     ],
 
+    "buildRequirements": ["silenceWarnings"],
+
     "targetName": "tango",
     "targetPath": "."
 }


### PR DESCRIPTION
This is currently required to build Tango successfully using Dub.
Remove when the isNaN warnings are properly fixed.
