### PR TITLE
Update for dmd/druntime HEAD.

### DIFF
--- a/tango/core/RuntimeTraits.d
+++ b/tango/core/RuntimeTraits.d
@@ -242,7 +242,7 @@ const(ClassInfo)[] baseTypes (const(ClassInfo) type)
 }
 
 ///
-ModuleInfo* moduleOf (const(ClassInfo) type)
+immutable(ModuleInfo)* moduleOf (const(ClassInfo) type)
 {
     foreach (modula; ModuleInfo)
         foreach (klass; modula.localClasses)

--- a/tango/text/Regex.d
+++ b/tango/text/Regex.d
@@ -2354,13 +2354,6 @@ private class TDFA(char_t)
                 return 0;
             return 1;
         }
-
-        const bool opEquals(ref const Command cmd)
-        {
-            if ( dst != cmd.dst || src != cmd.src )
-                return false;
-            return true;
-        }
     }
 
     struct TagIndex


### PR DESCRIPTION
- `ModuleInfo` now `immutable`.
- `toHash` is now required by AA if `opEquals` is declared.
