### PR TITLE
It is now `enum` of type `typeof(null)`.

### DIFF
--- a/tango/sys/win32/Types.d
+++ b/tango/sys/win32/Types.d
@@ -6,7 +6,7 @@ module tango.sys.win32.Types;
 */
 
 /+ Aliases, Types, and Constants +/
-const void* NULL = null;
+enum NULL = null;
 alias int SCODE;
 alias void VOID;
 alias void* POINTER;


### PR DESCRIPTION
Previously it was `const void*`.

Changes just this one as it is an often used macro when code is translated from C.
